### PR TITLE
Fix the vengo alias

### DIFF
--- a/bin/vengo.sh
+++ b/bin/vengo.sh
@@ -25,7 +25,7 @@ if [ "$VENGO_HOME" = "" ]; then
     . $VENGO_HOME/bin/includes/help
 fi
 
-alias vengo=${VENGO_HOME}/bin/vengo
+alias vengo=${VENGO_HOME}/bin/vengo.sh
 
 # VenGO activate script
 function vengo_activate {


### PR DESCRIPTION
The alias was missing the `.sh` extension, and it was not working on ZSH. _not sure if it worked somewhere else_